### PR TITLE
fix: fixed link to favicon

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <link rel="icon" type="image/png" href="/icon-circle.png" />
+    <link rel="icon" type="image/png" href="/media/icon-circle.png" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>James M. Drake, Jr.</title>
   </head>


### PR DESCRIPTION
media is now at /media/
favicon was still pointing to /